### PR TITLE
upgrades nan to version 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "gypfile": true,
   "readmeFilename": "README.md",
   "dependencies": {
-    "nan": "~2.0.9"
+    "nan": "~2.2.1"
   }
 }


### PR DESCRIPTION
```
gyp ERR! node -v v6.0.0
gyp ERR! node-gyp -v v3.3.1
```

Installation of the module with the above versions produces the error message below:

```
> node-gyp rebuild

  CXX(target) Release/obj.target/node_aes_gcm/src/node-aes-gcm.o
In file included from ../src/node-aes-gcm.cc:24:
../node_modules/nan/nan.h:590:20: error: no type named 'GCEpilogueCallback' in 'v8::Isolate'
      v8::Isolate::GCEpilogueCallback callback
      ~~~~~~~~~~~~~^
../node_modules/nan/nan.h:596:20: error: no type named 'GCEpilogueCallback' in 'v8::Isolate'
      v8::Isolate::GCEpilogueCallback callback) {
      ~~~~~~~~~~~~~^
../node_modules/nan/nan.h:601:20: error: no type named 'GCPrologueCallback' in 'v8::Isolate'
      v8::Isolate::GCPrologueCallback callback
      ~~~~~~~~~~~~~^
../node_modules/nan/nan.h:607:20: error: no type named 'GCPrologueCallback' in 'v8::Isolate'
      v8::Isolate::GCPrologueCallback callback) {
      ~~~~~~~~~~~~~^
4 errors generated.
make: *** [Release/obj.target/node_aes_gcm/src/node-aes-gcm.o] Error 1
```

upgrading `nan` fixes installation error with newer versions of v8. `npm test` completes successfully on all 43 tests.

I also tested installation and running tests with the following versions successfully:
* `5.10.1`
* `5.6.0`
* `4.4.2`
* `4.2.2`
*  `0.12.5`

It is worth noting that installation fails with node `5.0.0` (which does not currently seem to be the case), and the tests fail with node `0.10.43` (as they currently do).